### PR TITLE
Made compiler and watcher available to custom callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,17 +28,18 @@ filewatcherPlugin.prototype.apply = function(compiler) {
       atomic: options.atomic || true
     });
 
+    const callbackContext = { compiler, watcher };
     watcher
       .on(
         'add',
-        options.onAddCallback ||
+        options.onAddCallback ? options.onAddCallback.bind(callbackContext) :
           function(path) {
             return null;
           }
       )
       .on(
         'change',
-        options.onChangeCallback ||
+        options.onChangeCallback ? options.onChangeCallback.bind(callbackContext) :
           function(path) {
             console.log(`\n\n Compilation Started  after change of - ${path} \n\n`);
             compiler.run(function(err) {
@@ -50,7 +51,7 @@ filewatcherPlugin.prototype.apply = function(compiler) {
       )
       .on(
         'unlink',
-        options.onUnlinkCallback ||
+        options.onUnlinkCallback ? options.onUnlinkCallback.bind(callbackContext) :
           function(path) {
             console.log(`File ${path} has been removed`);
           }
@@ -59,35 +60,35 @@ filewatcherPlugin.prototype.apply = function(compiler) {
     watcher
       .on(
         'addDir',
-        options.onAddDirCallback ||
+        options.onAddDirCallback ? options.onAddDirCallback.bind(callbackContext) :
           function(path) {
             console.log(`Directory ${path} has been added`);
           }
       )
       .on(
         'unlinkDir',
-        options.unlinkDirCallback ||
+        options.unlinkDirCallback ? options.unlinkDirCallback.bind(callbackContext) :
           function(path) {
             console.log(`Directory ${path} has been removed`);
           }
       )
       .on(
         'error',
-        options.onErrorCallback ||
+        options.onErrorCallback ? options.onErrorCallback.bind(callbackContext) :
           function(error) {
             console.log(`Watcher error: ${error}`);
           }
       )
       .on(
         'ready',
-        options.onReadyCallback ||
+        options.onReadyCallback ? options.onReadyCallback.bind(callbackContext) :
           function() {
             console.log('Initial scan complete. Ready for changes');
           }
       )
       .on(
         'raw',
-        options.onRawCallback ||
+        options.onRawCallback ? options.onRawCallback.bind(callbackContext) :
           function(event, path, details) {
             return null;
           }


### PR DESCRIPTION
Fixes https://github.com/sap9433/filewatcher-webpack-plugin/issues/6, making it possible to access compiler and watcher in custom callbacks. Example, using debounce to simulate [aggregateTimeout](https://webpack.js.org/configuration/watch/#watchoptions-aggregatetimeout):

```
    new FilewatcherPlugin({
      onChangeCallback: debounce(function(path) {
        const callbackContext = this;
        console.log(`\n\n Compilation Started  after change of - ${path} \n\n`);
        callbackContext.compiler.run(function(err) {
          if (err) throw err;
          callbackContext.watcher.close();
        });
        console.log(`\n\n Compilation ended  for change of - ${path} \n\n`);
      }, 300),
```

To try this out / use this in your project:
```
npm install --save-dev motin/filewatcher-webpack-plugin#bound-custom-callbacks
```