### PR TITLE
Move dependencies unused into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^6.0.2",
-    "path": "^0.12.7"
-  },
-  "dependencies": {
-    "chokidar": "^2.1.5",
+    "path": "^0.12.7",
     "jsx-loader": "^0.13.2",
     "node-async-require-loader": "^2.0.0",
     "node-fetch": "^2.3.0",
     "react": "^16.8.6",
     "webpack": "^4.29.6",
     "webpack-dev-server": "^3.2.1"
+  },
+  "dependencies": {
+    "chokidar": "^2.1.5"
   }
 }


### PR DESCRIPTION
The index file only uses chokidar, so it should only have that in dependencies